### PR TITLE
Fixed missing comma for the CMD :-)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ ENV PATH /root/.composer/vendor/bin:$PATH
 ADD essentials.ini /etc/php5/cli/conf.d/99-essentials.ini
 
 
-CMD ["/usr/bin/php","-a"]
+CMD ["/usr/bin/php" , "-a"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ ENV PATH /root/.composer/vendor/bin:$PATH
 ADD essentials.ini /etc/php5/cli/conf.d/99-essentials.ini
 
 
-CMD ["/usr/bin/php" "-a"]
+CMD ["/usr/bin/php","-a"]


### PR DESCRIPTION
Fixed the "/bin/sh: 1: [/usr/bin/php: not found" issue (due to missing comma)
